### PR TITLE
If dpr initially unknown, update in subsequent page impression

### DIFF
--- a/Columns/DevicePixelRatio.php
+++ b/Columns/DevicePixelRatio.php
@@ -94,6 +94,11 @@ class DevicePixelRatio extends VisitDimension
      */
     public function onExistingVisit(Request $request, Visitor $visitor, $action)
     {
-        return false;
+        // In case the value was initially unknown, update it from a subsequent page impression
+        if (is_null($visitor->getVisitorColumn($this->columnName))) {
+            return $this->onNewVisit($request, $visitor, $action);
+        } else {
+            return false;
+        }
     }
 }

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,12 +1,14 @@
 ## FAQ
 
-__Shouldn't the plugin analyze the pure device pixel ratio, wihtout taking the zoom into account?__
+__Shouldn't the plugin analyze the pure device pixel ratio, without taking the zoom into account?__
 
-I do not think that you can query the browser for neither the full page zoom nor the pure pixel device ratio, window.pixelDeviceRatio gives you both at the same time.
+I do not think that you can query the browser for either the full page zoom or the pure pixel device ratio, window.pixelDeviceRatio gives you both at the same time.
 
 __What if the device pixel ratio changes during the visit (e.g. by the user changing the full page zoom level)?__
 
 The plugin records the device pixel ratio at the beginning of each visit, later changes are ignored.  I might think about an option for taking the value for the last action instead, if you provide me with very good arguments for that.
+
+The exception to this is if the device pixel ratio is initially unknown (for example if the first tracking event of a visit is generated server-side via the API). In this case the plugin will record the first known value from a subsquent tracking event in the visit.
 
 __An unknown device pixel ratio is reported for all visitors.  What is wrong?__
 


### PR DESCRIPTION
Fix to address the issue mentioned here:
https://github.com/johsin18/DevicePixelRatioMatomoPlugin/issues/3

Have submitted a similar PR for the Matomo Core Resolution plugin.
https://github.com/matomo-org/matomo/pull/22080